### PR TITLE
chore(playground): set charset in content-type header

### DIFF
--- a/playground/app.mjs
+++ b/playground/app.mjs
@@ -10,7 +10,7 @@ const server = serve({
       `,
       {
         headers: {
-          "Content-Type": "text/html",
+          "Content-Type": "text/html; charset=UTF-8",
         },
       },
     );


### PR DESCRIPTION
The emoji in the example HTML response may not render correctly in the playground's iframe (or when running the code locally) without a charset declared in the HTML or in the `Content-Type` header.

<img width="627" alt="Screenshot: a web page in a browser with the UTF-8-encoded text being rendered as latin1 characters" src="https://github.com/user-attachments/assets/3fd3a315-568f-4de7-80f7-e9fb7834a200">
