### PR TITLE
doc: fix links

### DIFF
--- a/docs/1.guide/1.index.md
+++ b/docs/1.guide/1.index.md
@@ -4,7 +4,7 @@ icon: ph:book-open-duotone
 
 # Getting started
 
-srvx provides a unified standard API to create HTTP servers based on the standard web platform primitives ([fetch][fetch], [Request][Request] and [Response][Response]) and works seamlessly with [Deno](Deno), [Bun](Bun) and [Node.js](Node.js).
+srvx provides a unified standard API to create HTTP servers based on the standard web platform primitives ([fetch][fetch], [Request][Request] and [Response][Response]) and works seamlessly with [Deno][Deno], [Bun][Bun] and [Node.js][Node.js].
 
 ::read-more{to="/guide/why"}
 Why srvx?
@@ -14,18 +14,9 @@ Why srvx?
 How srvx is different from express, h3, nitro, ...
 ::
 
-For [Deno](Deno) and [Bun](Bun) srvx unifies interface with zero overhead and for [Node.js][Node.js], creates a lightweight compatibility layer to wrap [node:IncomingMessage](IncomingMessage) as a standard [Request](Request) object and convert final state of [node:ServerResponse](ServerResponse) to a standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object.
+For [Deno][Deno] and [Bun][Bun] srvx unifies interface with zero overhead and for [Node.js][Node.js], creates a lightweight compatibility layer to wrap [node:IncomingMessage][IncomingMessage] as a standard [Request][Request] object and convert final state of [node:ServerResponse][ServerResponse] to a standard [Response][Response] object.
 
 :read-more{to="/guide/node" title="Node.js support"}
-
-[Deno]: https://deno.com/
-[Bun]: https://bun.sh/
-[Node.js]: https://nodejs.org/
-[fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
-[Request]: https://developer.mozilla.org/en-US/docs/Web/API/Request
-[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
-[IncomingMessage]: https://nodejs.org/api/http.html#http_class_http_incomingmessage
-[ServerResponse]: https://nodejs.org/api/http.html#http_class_http_serverresponse
 
 ## Quick start
 
@@ -44,3 +35,12 @@ await server.ready();
 
 console.log(`🚀 Server ready at ${server.url}`);
 ```
+
+[Deno]: https://deno.com/
+[Bun]: https://bun.sh/
+[Node.js]: https://nodejs.org/
+[fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+[Request]: https://developer.mozilla.org/en-US/docs/Web/API/Request
+[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
+[IncomingMessage]: https://nodejs.org/api/http.html#http_class_http_incomingmessage
+[ServerResponse]: https://nodejs.org/api/http.html#http_class_http_serverresponse

--- a/docs/1.guide/7.node.md
+++ b/docs/1.guide/7.node.md
@@ -68,7 +68,7 @@ You can locally run benchmarks by cloning [srvx repository](https://github.com/u
 
 ## Reverse compatibility
 
-srvx converts a [fetch][fetch]-like [Request][Request] => [Response][Response] handler to [node:IncomingMessage](IncomingMessage) => [node:ServerResponse](ServerResponse) handler that is compatible **with** Node.js runtime.
+srvx converts a [fetch][fetch]-like [Request][Request] => [Response][Response] handler to [node:IncomingMessage][IncomingMessage] => [node:ServerResponse][ServerResponse] handler that is compatible **with** Node.js runtime.
 
 If you want to instead convert a Node.js server handler (like [Express][Express]) with `(req, IncomingMessage, res: ServerResponse)` signature to [fetch][fetch]-like handler ([Request][Request] => [Response][Response]) that can work **without** Node.js runtime you can instead use [unjs/unenv](https://unenv.unjs.io) Node.js compatibility layer to emulate Node.js API.
 
@@ -86,8 +86,6 @@ const res = await serverFetch("/test", { headers: { foo: "bar" } });
 console.log(res);
 ```
 
-[Deno]: https://deno.com/
-[Bun]: https://bun.sh/
 [Node.js]: https://nodejs.org/
 [fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 [Request]: https://developer.mozilla.org/en-US/docs/Web/API/Request


### PR DESCRIPTION
Some ref links were using `()`

