### PR TITLE
fix(node): flatten headers to handle node slow path

### DIFF
--- a/src/_node-compat/send.ts
+++ b/src/_node-compat/send.ts
@@ -16,7 +16,7 @@ export async function sendNodeResponse(
   if ((webRes as NodeFastResponse).nodeResponse) {
     const res = (webRes as NodeFastResponse).nodeResponse();
     if (!nodeRes.headersSent) {
-      nodeRes.writeHead(res.status, res.statusText, res.headers);
+      nodeRes.writeHead(res.status, res.statusText, res.headers.flat());
     }
     if (res.body) {
       if (res.body instanceof ReadableStream) {
@@ -42,7 +42,11 @@ export async function sendNodeResponse(
   }
 
   if (!nodeRes.headersSent) {
-    nodeRes.writeHead(webRes.status || 200, webRes.statusText, headerEntries);
+    nodeRes.writeHead(
+      webRes.status || 200,
+      webRes.statusText,
+      headerEntries.flat(),
+    );
   }
 
   return webRes.body

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -38,6 +38,18 @@ export const server = serve({
       case "/": {
         return new Response("ok");
       }
+      case "/headers": {
+        // Trigger Node.js writeHead slowpath to reproduce issue
+        req.node?.res.setHeader("x-set-with-node", "true");
+        const resHeaders = new Headers();
+        for (const [key, value] of req.headers) {
+          resHeaders.append(`x-req-${key}`, value);
+        }
+        return new Response(
+          JSON.stringify(Object.fromEntries(req.headers.entries())),
+          { headers: resHeaders },
+        );
+      }
       case "/body/binary": {
         return new Response(req.body);
       }

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -39,8 +39,8 @@ export const server = serve({
         return new Response("ok");
       }
       case "/headers": {
-        // Trigger Node.js writeHead slowpath to reproduce issue
-        req.node?.res.setHeader("x-set-with-node", "true");
+        // Trigger Node.js writeHead slowpath to reproduce https://github.com/unjs/srvx/pull/40
+        req.node?.res.setHeader("x-set-with-node", "");
         const resHeaders = new Headers();
         for (const [key, value] of req.headers) {
           resHeaders.append(`x-req-${key}`, value);

--- a/test/_tests.ts
+++ b/test/_tests.ts
@@ -22,6 +22,16 @@ export function addTests(
     expect(await response.text()).toMatch("yes");
   });
 
+  test("headers", async () => {
+    const response = await fetch(url("/headers"), {
+      headers: { foo: "bar", bar: "baz" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ foo: "bar", bar: "baz" });
+    expect(response.headers.get("x-req-foo")).toBe("bar");
+    expect(response.headers.get("x-req-bar")).toBe("baz");
+  });
+
   test("POST works (binary body)", async () => {
     const response = await fetch(url("/body/binary"), {
       method: "POST",


### PR DESCRIPTION
discovered from https://github.com/nitrojs/nitro/pull/3208/

Node.js has a [slow path](http://github.com/nodejs/node/blob/v22.14.0/lib/_http_server.js#L377) for `res.writeHead` that only triggers if `res.setHeader` is called before.

In this case only (seems an implementation inconsistency) flatten array of key/value touples is expected.