### PR TITLE
refactor!: move extended request context under `request.x.*`

### DIFF
--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -15,7 +15,7 @@ serve({
     return new Response(
       `
         <h1>👋 Hello there</h1>
-        <p>You are visiting ${request.url} from ${request.x.ip}</p>
+        <p>You are visiting ${request.url} from ${request.x?.ip}</p>
       `,
       { headers: { "Content-Type": "text/html" } },
     );

--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -10,7 +10,6 @@ Request handler is defined via `fetch` key since it is similar to [fetch][fetch]
 
 ```js
 import { serve } from "srvx";
-
 serve({
   async fetch(request) {
     return new Response(
@@ -24,14 +23,10 @@ serve({
 });
 ```
 
-## Additional properties
-
-> srvx **never** patches, overrides or extends globals such as [Request][Request] and [Response][Response]. Only few lazy getters prefixed with `x` will optionally be added to the `request` object instance to allow server adoption of [Request][Request].
-
 > [!TIP]
-> You can use `ServerRequest` type for TypeScript usage.
+> You can use `ServerRequest` type export from `srvx` as type of `request`.
 
-### `request.remoteAddress?`
+## `request.remoteAddress?`
 
 Using `request.remoteAddress` allows to access connected client's ipv4/ipv6 address or hostname.
 
@@ -44,21 +39,29 @@ serve({
 });
 ```
 
-### `request.bun?`
+## `request.runtime?`
+
+Holds runtime additional context.
+
+### `request.runtime?.name?`
+
+Runtime name. Can be `"bun"`, `"deno"`, `"node"`, `"cloudflare"` or any other string.
+
+### `request.runtime?.bun?`
 
 Using `request.bun?.server` you can access to the underlying Bun server.
 
-### `request.deno?`
+### `request.runtime?.deno?`
 
 Using `request.deno?.server` you can access to the underlying Deno server.
 
 Using `request.deno?.info` you can access to the extra request information provided by Deno.
 
-### `request.node?`
+### `request.runtime?.node?`
 
 [Node.js][Node.js] is supported through a proxy that wraps [node:IncomingMessage][IncomingMessage] as [Request][Request] and converting final state of [node:ServerResponse][ServerResponse] to [Response][Response].
 
-If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.node?.res` ([node:ServerResponse][ServerResponse]).
+If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.runtime?.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.runtime?.node?.res` ([node:ServerResponse][ServerResponse]).
 
 ```js
 import { serve } from "srvx";

--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -58,7 +58,7 @@ Using `request.deno?.info` you can access to the extra request information provi
 
 [Node.js][Node.js] is supported through a proxy that wraps [node:IncomingMessage][IncomingMessage] as [Request][Request] and converting final state of [node:ServerResponse][ServerResponse] to [Response][Response].
 
-If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.runtime?.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.runtime?.node?.res` ([node:ServerResponse][ServerResponse]).
+If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.x?.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.x?.node?.res` ([node:ServerResponse][ServerResponse]).
 
 ```js
 import { serve } from "srvx";

--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -15,7 +15,7 @@ serve({
     return new Response(
       `
         <h1>👋 Hello there</h1>
-        <p>You are visiting ${request.url} from ${request.remoteAddress}</p>
+        <p>You are visiting ${request.url} from ${request.x.ip}</p>
       `,
       { headers: { "Content-Type": "text/html" } },
     );
@@ -26,38 +26,35 @@ serve({
 > [!TIP]
 > You can use `ServerRequest` type export from `srvx` as type of `request`.
 
-## `request.remoteAddress?`
+## Extended request context
 
-Using `request.remoteAddress` allows to access connected client's ipv4/ipv6 address or hostname.
+### `request.x?.ip?`
+
+Using `request.ip` allows to access connected client's ipv4/ipv6 address or hostname.
 
 ```js
 import { serve } from "srvx";
 
 serve({
-  fetch: (request) =>
-    new Response(`Your ip address is "${request.remoteAddress}"`),
+  fetch: (request) => new Response(`Your ip address is "${request.x?.ip}"`),
 });
 ```
 
-## `request.runtime?`
-
-Holds runtime additional context.
-
-### `request.runtime?.name?`
+### `request.x?.runtime?`
 
 Runtime name. Can be `"bun"`, `"deno"`, `"node"`, `"cloudflare"` or any other string.
 
-### `request.runtime?.bun?`
+### `request.x?.bun?`
 
 Using `request.bun?.server` you can access to the underlying Bun server.
 
-### `request.runtime?.deno?`
+### `request.x?.deno?`
 
 Using `request.deno?.server` you can access to the underlying Deno server.
 
 Using `request.deno?.info` you can access to the extra request information provided by Deno.
 
-### `request.runtime?.node?`
+### `request.x?.node?`
 
 [Node.js][Node.js] is supported through a proxy that wraps [node:IncomingMessage][IncomingMessage] as [Request][Request] and converting final state of [node:ServerResponse][ServerResponse] to [Response][Response].
 

--- a/src/_node-compat/headers.ts
+++ b/src/_node-compat/headers.ts
@@ -4,18 +4,18 @@ import { kNodeInspect } from "./_common.ts";
 
 export const NodeRequestHeaders = /* @__PURE__ */ (() => {
   const _Headers = class Headers implements globalThis.Headers {
-    node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
+    _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
 
     constructor(nodeCtx: {
       req: NodeHttp.IncomingMessage;
       res?: NodeHttp.ServerResponse;
     }) {
-      this.node = nodeCtx;
+      this._node = nodeCtx;
     }
 
     append(name: string, value: string): void {
       name = name.toLowerCase();
-      const _headers = this.node.req.headers;
+      const _headers = this._node.req.headers;
       const _current = _headers[name];
       if (_current) {
         if (Array.isArray(_current)) {
@@ -30,20 +30,20 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
 
     delete(name: string): void {
       name = name.toLowerCase();
-      this.node.req.headers[name] = undefined;
+      this._node.req.headers[name] = undefined;
     }
 
     get(name: string): string | null {
       name = name.toLowerCase();
-      const rawValue = this.node.req.headers[name];
+      const rawValue = this._node.req.headers[name];
       if (rawValue === undefined) {
         return null;
       }
-      return _normalizeValue(this.node.req.headers[name]);
+      return _normalizeValue(this._node.req.headers[name]);
     }
 
     getSetCookie(): string[] {
-      const setCookie = this.node.req.headers["set-cookie"];
+      const setCookie = this._node.req.headers["set-cookie"];
       if (!setCookie || setCookie.length === 0) {
         return [];
       }
@@ -52,12 +52,12 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
 
     has(name: string): boolean {
       name = name.toLowerCase();
-      return !!this.node.req.headers[name];
+      return !!this._node.req.headers[name];
     }
 
     set(name: string, value: string): void {
       name = name.toLowerCase();
-      this.node.req.headers[name] = value;
+      this._node.req.headers[name] = value;
     }
 
     get count(): number {
@@ -71,7 +71,7 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
     }
 
     toJSON(): Record<string, string> {
-      const _headers = this.node.req.headers;
+      const _headers = this._node.req.headers;
       const result: Record<string, string> = {};
       for (const key in _headers) {
         if (_headers[key]) {
@@ -85,7 +85,7 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
       cb: (value: string, key: string, parent: Headers) => void,
       thisArg?: any,
     ): void {
-      const _headers = this.node.req.headers;
+      const _headers = this._node.req.headers;
       for (const key in _headers) {
         if (_headers[key]) {
           cb.call(
@@ -99,21 +99,21 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
     }
 
     *entries(): HeadersIterator<[string, string]> {
-      const _headers = this.node.req.headers;
+      const _headers = this._node.req.headers;
       for (const key in _headers) {
         yield [key, _normalizeValue(_headers[key])];
       }
     }
 
     *keys(): HeadersIterator<string> {
-      const keys = Object.keys(this.node.req.headers);
+      const keys = Object.keys(this._node.req.headers);
       for (const key of keys) {
         yield key;
       }
     }
 
     *values(): HeadersIterator<string> {
-      const values = Object.values(this.node.req.headers);
+      const values = Object.values(this._node.req.headers);
       for (const value of values) {
         yield _normalizeValue(value);
       }
@@ -139,25 +139,25 @@ export const NodeRequestHeaders = /* @__PURE__ */ (() => {
 
 export const NodeResponseHeaders = /* @__PURE__ */ (() => {
   const _Headers = class Headers implements globalThis.Headers {
-    node: { req?: NodeHttp.IncomingMessage; res: NodeHttp.ServerResponse };
+    _node: { req?: NodeHttp.IncomingMessage; res: NodeHttp.ServerResponse };
 
     constructor(nodeCtx: {
       req?: NodeHttp.IncomingMessage;
       res: NodeHttp.ServerResponse;
     }) {
-      this.node = nodeCtx;
+      this._node = nodeCtx;
     }
 
     append(name: string, value: string): void {
-      this.node.res.appendHeader(name, value);
+      this._node.res.appendHeader(name, value);
     }
 
     delete(name: string): void {
-      this.node.res.removeHeader(name);
+      this._node.res.removeHeader(name);
     }
 
     get(name: string): string | null {
-      const rawValue = this.node.res.getHeader(name);
+      const rawValue = this._node.res.getHeader(name);
       if (rawValue === undefined) {
         return null;
       }
@@ -165,7 +165,7 @@ export const NodeResponseHeaders = /* @__PURE__ */ (() => {
     }
 
     getSetCookie(): string[] {
-      const setCookie = _normalizeValue(this.node.res.getHeader("set-cookie"));
+      const setCookie = _normalizeValue(this._node.res.getHeader("set-cookie"));
       if (!setCookie) {
         return [];
       }
@@ -173,11 +173,11 @@ export const NodeResponseHeaders = /* @__PURE__ */ (() => {
     }
 
     has(name: string): boolean {
-      return this.node.res.hasHeader(name);
+      return this._node.res.hasHeader(name);
     }
 
     set(name: string, value: string): void {
-      this.node.res.setHeader(name, value);
+      this._node.res.setHeader(name, value);
     }
 
     get count(): number {
@@ -191,7 +191,7 @@ export const NodeResponseHeaders = /* @__PURE__ */ (() => {
     }
 
     toJSON(): Record<string, string> {
-      const _headers = this.node.res.getHeaders();
+      const _headers = this._node.res.getHeaders();
       const result: Record<string, string> = {};
       for (const key in _headers) {
         if (_headers[key]) {
@@ -205,7 +205,7 @@ export const NodeResponseHeaders = /* @__PURE__ */ (() => {
       cb: (value: string, key: string, parent: Headers) => void,
       thisArg?: any,
     ): void {
-      const _headers = this.node.res.getHeaders();
+      const _headers = this._node.res.getHeaders();
       for (const key in _headers) {
         if (_headers[key]) {
           cb.call(
@@ -219,21 +219,21 @@ export const NodeResponseHeaders = /* @__PURE__ */ (() => {
     }
 
     *entries(): HeadersIterator<[string, string]> {
-      const _headers = this.node.res.getHeaders();
+      const _headers = this._node.res.getHeaders();
       for (const key in _headers) {
         yield [key, _normalizeValue(_headers[key])];
       }
     }
 
     *keys(): HeadersIterator<string> {
-      const keys = this.node.res.getHeaderNames();
+      const keys = this._node.res.getHeaderNames();
       for (const key of keys) {
         yield key;
       }
     }
 
     *values(): HeadersIterator<string> {
-      const values = Object.values(this.node.res.getHeaders());
+      const values = Object.values(this._node.res.getHeaders());
       for (const value of values) {
         yield _normalizeValue(value);
       }

--- a/src/_node-compat/request.ts
+++ b/src/_node-compat/request.ts
@@ -19,14 +19,20 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     #bodyStream?: undefined | ReadableStream<Uint8Array>;
 
     _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
-    runtime: ServerRuntimeContext;
+    x: ServerRuntimeContext;
 
     constructor(nodeCtx: {
       req: NodeHttp.IncomingMessage;
       res?: NodeHttp.ServerResponse;
     }) {
       this._node = nodeCtx;
-      this.runtime = { name: "node", node: nodeCtx };
+      this.x = {
+        runtime: "node",
+        node: nodeCtx,
+        get ip() {
+          return nodeCtx.req.socket?.remoteAddress;
+        },
+      };
     }
 
     get headers() {
@@ -34,10 +40,6 @@ export const NodeRequest = /* @__PURE__ */ (() => {
         this.#headers = new NodeRequestHeaders(this._node);
       }
       return this.#headers;
-    }
-
-    get remoteAddress() {
-      return this._node.req.socket?.remoteAddress;
     }
 
     clone() {

--- a/src/_node-compat/request.ts
+++ b/src/_node-compat/request.ts
@@ -1,5 +1,5 @@
 import type NodeHttp from "node:http";
-import type { ServerRequest } from "../types.ts";
+import type { ServerRequest, ServerRuntimeContext } from "../types.ts";
 import { kNodeInspect } from "./_common.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { NodeRequestURL } from "./url.ts";
@@ -18,33 +18,35 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     #textBody?: Promise<string>;
     #bodyStream?: undefined | ReadableStream<Uint8Array>;
 
-    node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
+    _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
+    runtime: ServerRuntimeContext;
 
     constructor(nodeCtx: {
       req: NodeHttp.IncomingMessage;
       res?: NodeHttp.ServerResponse;
     }) {
-      this.node = nodeCtx;
+      this._node = nodeCtx;
+      this.runtime = { name: "node", node: nodeCtx };
     }
 
     get headers() {
       if (!this.#headers) {
-        this.#headers = new NodeRequestHeaders(this.node);
+        this.#headers = new NodeRequestHeaders(this._node);
       }
       return this.#headers;
     }
 
     get remoteAddress() {
-      return this.node.req.socket?.remoteAddress;
+      return this._node.req.socket?.remoteAddress;
     }
 
     clone() {
-      return new _Request({ ...this.node });
+      return new _Request({ ...this._node });
     }
 
     get _url() {
       if (!this.#url) {
-        this.#url = new NodeRequestURL(this.node);
+        this.#url = new NodeRequestURL(this._node);
       }
       return this.#url;
     }
@@ -54,7 +56,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     }
 
     get method() {
-      return this.node.req.method || "GET";
+      return this._node.req.method || "GET";
     }
 
     get signal() {
@@ -73,7 +75,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
         return this.#hasBody;
       }
       // Check if request method requires a payload
-      const method = this.node.req.method?.toUpperCase();
+      const method = this._node.req.method?.toUpperCase();
       if (
         !method ||
         !(
@@ -88,8 +90,8 @@ export const NodeRequest = /* @__PURE__ */ (() => {
       }
 
       // Make sure either content-length or transfer-encoding/chunked is set
-      if (!Number.parseInt(this.node.req.headers["content-length"] || "")) {
-        const isChunked = (this.node.req.headers["transfer-encoding"] || "")
+      if (!Number.parseInt(this._node.req.headers["content-length"] || "")) {
+        const isChunked = (this._node.req.headers["transfer-encoding"] || "")
           .split(",")
           .map((e) => e.trim())
           .filter(Boolean)
@@ -111,7 +113,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
         this.#bodyUsed = true;
         this.#bodyStream = new ReadableStream({
           start: (controller) => {
-            this.node.req
+            this._node.req
               .on("data", (chunk) => {
                 controller.enqueue(chunk);
               })
@@ -154,7 +156,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
       if (!this.#blobBody) {
         this.#blobBody = this.bytes().then((bytes) => {
           return new Blob([bytes], {
-            type: this.node.req.headers["content-type"],
+            type: this._node.req.headers["content-type"],
           });
         });
       }

--- a/src/_node-compat/url.ts
+++ b/src/_node-compat/url.ts
@@ -3,7 +3,7 @@ import { kNodeInspect } from "./_common.ts";
 
 export const NodeRequestURL = /* @__PURE__ */ (() => {
   const _URL = class URL implements Partial<globalThis.URL> {
-    node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
+    _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
 
     _hash = "";
     _username = "";
@@ -20,7 +20,7 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
       req: NodeHttp.IncomingMessage;
       res?: NodeHttp.ServerResponse;
     }) {
-      this.node = nodeCtx;
+      this._node = nodeCtx;
     }
 
     get hash() {
@@ -49,18 +49,18 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
 
     // host
     get host() {
-      return this.node.req.headers.host || "";
+      return this._node.req.headers.host || "";
     }
     set host(value: string) {
       this._hostname = undefined;
       this._port = undefined;
-      this.node.req.headers.host = value;
+      this._node.req.headers.host = value;
     }
 
     // hostname
     get hostname() {
       if (this._hostname === undefined) {
-        const [hostname, port] = parseHost(this.node.req.headers.host);
+        const [hostname, port] = parseHost(this._node.req.headers.host);
         if (this._port === undefined && port) {
           this._port = String(Number.parseInt(port) || "");
         }
@@ -75,11 +75,11 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
     // port
     get port() {
       if (this._port === undefined) {
-        const [hostname, port] = parseHost(this.node.req.headers.host);
+        const [hostname, port] = parseHost(this._node.req.headers.host);
         if (this._hostname === undefined && hostname) {
           this._hostname = hostname;
         }
-        this._port = port || String(this.node.req.socket?.localPort || "");
+        this._port = port || String(this._node.req.socket?.localPort || "");
       }
       return this._port;
     }
@@ -90,7 +90,7 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
     // pathname
     get pathname() {
       if (this._pathname === undefined) {
-        const [pathname, search] = parsePath(this.node.req.url || "/");
+        const [pathname, search] = parsePath(this._node.req.url || "/");
         this._pathname = pathname;
         if (this._search === undefined) {
           this._search = search;
@@ -106,13 +106,13 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
         return;
       }
       this._pathname = value;
-      this.node.req.url = value + this.search;
+      this._node.req.url = value + this.search;
     }
 
     // search
     get search() {
       if (this._search === undefined) {
-        const [pathname, search] = parsePath(this.node.req.url || "/");
+        const [pathname, search] = parsePath(this._node.req.url || "/");
         this._search = search;
         if (this._pathname === undefined) {
           this._pathname = pathname;
@@ -131,7 +131,7 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
       }
       this._search = value;
       this._searchParams = undefined;
-      this.node.req.url = this.pathname + value;
+      this._node.req.url = this.pathname + value;
     }
 
     // searchParams
@@ -150,8 +150,8 @@ export const NodeRequestURL = /* @__PURE__ */ (() => {
     get protocol() {
       if (!this._protocol) {
         this._protocol =
-          (this.node.req.socket as any)?.encrypted ||
-          this.node.req.headers["x-forwarded-proto"] === "https"
+          (this._node.req.socket as any)?.encrypted ||
+          this._node.req.headers["x-forwarded-proto"] === "https"
             ? "https:"
             : "http:";
       }

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -25,7 +25,10 @@ class BunServer implements Server<BunFetchHandler> {
 
     this.fetch = (request, server) => {
       Object.defineProperties(request, {
-        bun: { value: { server }, enumerable: true },
+        runtime: {
+          enumerable: true,
+          value: { name: "bun", bun: { server } },
+        },
         remoteAddress: {
           get: () => server?.requestIP(request as Request)?.address,
           enumerable: true,

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -24,14 +24,14 @@ class BunServer implements Server<BunFetchHandler> {
     const fetchHandler = wrapFetch(this, this.options.fetch);
 
     this.fetch = (request, server) => {
-      Object.defineProperties(request, {
-        runtime: {
-          enumerable: true,
-          value: { name: "bun", bun: { server } },
-        },
-        remoteAddress: {
-          get: () => server?.requestIP(request as Request)?.address,
-          enumerable: true,
+      Object.defineProperty(request, "x", {
+        enumerable: true,
+        value: {
+          runtime: "bun",
+          bun: { server },
+          get ip() {
+            return server?.requestIP(request as Request)?.address;
+          },
         },
       });
       return fetchHandler(request);

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -30,7 +30,10 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
 
     this.fetch = (request, env, context) => {
       Object.defineProperties(request, {
-        cloudflare: { value: { env, context }, enumerable: true },
+        runtime: {
+          enumerable: true,
+          value: { name: "cloudflare", cloudflare: { env, context } },
+        },
         remoteAddress: {
           get: () => undefined,
           enumerable: true,

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -29,14 +29,11 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
     );
 
     this.fetch = (request, env, context) => {
-      Object.defineProperties(request, {
-        runtime: {
-          enumerable: true,
-          value: { name: "cloudflare", cloudflare: { env, context } },
-        },
-        remoteAddress: {
-          get: () => undefined,
-          enumerable: true,
+      Object.defineProperty(request, "x", {
+        enumerable: true,
+        value: {
+          runtime: "cloudflare",
+          cloudflare: { env, context },
         },
       });
       return fetchHandler(request as unknown as Request) as unknown as

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -29,7 +29,10 @@ class DenoServer implements Server<DenoFetchHandler> {
 
     this.fetch = (request, info) => {
       Object.defineProperties(request, {
-        deno: { value: { info, server: this.deno?.server }, enumerable: true },
+        runtime: {
+          enumerable: true,
+          value: { name: "deno", deno: { info, server: this.deno?.server } },
+        },
         remoteAddress: {
           get: () => (info?.remoteAddr as Deno.NetAddr)?.hostname,
           enumerable: true,

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -28,14 +28,14 @@ class DenoServer implements Server<DenoFetchHandler> {
     const fetchHandler = wrapFetch(this, this.options.fetch);
 
     this.fetch = (request, info) => {
-      Object.defineProperties(request, {
-        runtime: {
-          enumerable: true,
-          value: { name: "deno", deno: { info, server: this.deno?.server } },
-        },
-        remoteAddress: {
-          get: () => (info?.remoteAddr as Deno.NetAddr)?.hostname,
-          enumerable: true,
+      Object.defineProperty(request, "x", {
+        enumerable: true,
+        value: {
+          runtime: "deno",
+          deno: { info, server: this.deno?.server },
+          get ip() {
+            return (info?.remoteAddr as Deno.NetAddr)?.hostname;
+          },
         },
       });
       return fetchHandler(request);

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,18 +206,15 @@ export interface ServerPluginInstance {
 // Request with runtime addons.
 // ----------------------------------------------------------------------------
 
-export interface ServerRequest extends Request {
-  /**
-   * Remote address of the client.
-   */
-  remoteAddress?: string | undefined;
+export interface ServerRuntimeContext {
+  name: "node" | "deno" | "bun" | "cloudflare" | (string & {});
 
   /**
    * Underlying Node.js server request info.
    */
   node?: {
     req: NodeHttp.IncomingMessage;
-    res: NodeHttp.ServerResponse;
+    res?: NodeHttp.ServerResponse;
   };
 
   /**
@@ -241,6 +238,18 @@ export interface ServerRequest extends Request {
     env: unknown;
     context: CF.ExecutionContext;
   };
+}
+
+export interface ServerRequest extends Request {
+  /**
+   * Runtime specific request context.
+   */
+  runtime?: ServerRuntimeContext;
+
+  /**
+   * Remote address of the client.
+   */
+  remoteAddress?: string | undefined;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,7 +207,12 @@ export interface ServerPluginInstance {
 // ----------------------------------------------------------------------------
 
 export interface ServerRuntimeContext {
-  name: "node" | "deno" | "bun" | "cloudflare" | (string & {});
+  runtime: "node" | "deno" | "bun" | "cloudflare" | (string & {});
+
+  /**
+   * IP address of the client.
+   */
+  ip?: string | undefined;
 
   /**
    * Underlying Node.js server request info.
@@ -244,12 +249,7 @@ export interface ServerRequest extends Request {
   /**
    * Runtime specific request context.
    */
-  runtime?: ServerRuntimeContext;
-
-  /**
-   * Remote address of the client.
-   */
-  remoteAddress?: string | undefined;
+  x?: ServerRuntimeContext;
 }
 
 // ----------------------------------------------------------------------------

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -40,7 +40,7 @@ export const server = serve({
       }
       case "/headers": {
         // Trigger Node.js writeHead slowpath to reproduce https://github.com/unjs/srvx/pull/40
-        req.runtime?.node?.res?.setHeader("x-set-with-node", "");
+        req.x?.node?.res?.setHeader("x-set-with-node", "");
         const resHeaders = new Headers();
         for (const [key, value] of req.headers) {
           resHeaders.append(`x-req-${key}`, value);
@@ -62,7 +62,7 @@ export const server = serve({
         return new Response(await req.text());
       }
       case "/ip": {
-        return new Response(`ip: ${req.remoteAddress}`);
+        return new Response(`ip: ${req.x?.ip}`);
       }
       case "/req-instanceof": {
         return new Response(req instanceof Request ? "yes" : "no");

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -40,7 +40,7 @@ export const server = serve({
       }
       case "/headers": {
         // Trigger Node.js writeHead slowpath to reproduce https://github.com/unjs/srvx/pull/40
-        req.node?.res.setHeader("x-set-with-node", "");
+        req.runtime?.node?.res?.setHeader("x-set-with-node", "");
         const resHeaders = new Headers();
         for (const [key, value] of req.headers) {
           resHeaders.append(`x-req-${key}`, value);

--- a/test/_tests.ts
+++ b/test/_tests.ts
@@ -57,7 +57,7 @@ export function addTests(
     expect(await response.text()).toBe("hello world");
   });
 
-  test("remoteAddress", async () => {
+  test("ip", async () => {
     const response = await fetch(url("/ip"));
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/ip: ::1|ip: 127.0.0.1/);


### PR DESCRIPTION
Attaching `request.{key}` props makes runtime-specific addons harder to distinguish and extend from the rest of the standard request props.

This PR is an API breaking change that moved them under `x` key (`request.x?.ip`, `request.x?.runtime`, `request.x?.node`, ..)

Types now can be also easily extended from `ServerRuntimeContext`.

Node.js polyfills now use `_node` for internal node context (still available via `request.runtime` too)