### PR TITLE
refactor!: use `request.ip` and `request.runtime`

### DIFF
--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -15,7 +15,7 @@ serve({
     return new Response(
       `
         <h1>👋 Hello there</h1>
-        <p>You are visiting ${request.url} from ${request.x?.ip}</p>
+        <p>You are visiting ${request.url} from ${request.ip}</p>
       `,
       { headers: { "Content-Type": "text/html" } },
     );
@@ -28,37 +28,37 @@ serve({
 
 ## Extended request context
 
-### `request.x?.ip?`
+### `request.ip?`
 
-Using `request.ip` allows to access connected client's ipv4/ipv6 address or hostname.
+Using `request.ip` allows to access connected client's ipv address.
 
 ```js
 import { serve } from "srvx";
 
 serve({
-  fetch: (request) => new Response(`Your ip address is "${request.x?.ip}"`),
+  fetch: (request) => new Response(`Your ip address is "${request.ip}"`),
 });
 ```
 
-### `request.x?.runtime?`
+### `request.runtime?.name?`
 
 Runtime name. Can be `"bun"`, `"deno"`, `"node"`, `"cloudflare"` or any other string.
 
-### `request.x?.bun?`
+### `request.runtime?.bun?`
 
 Using `request.bun?.server` you can access to the underlying Bun server.
 
-### `request.x?.deno?`
+### `request.runtime?.deno?`
 
 Using `request.deno?.server` you can access to the underlying Deno server.
 
 Using `request.deno?.info` you can access to the extra request information provided by Deno.
 
-### `request.x?.node?`
+### `request.runtime?.node?`
 
 [Node.js][Node.js] is supported through a proxy that wraps [node:IncomingMessage][IncomingMessage] as [Request][Request] and converting final state of [node:ServerResponse][ServerResponse] to [Response][Response].
 
-If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.x?.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.x?.node?.res` ([node:ServerResponse][ServerResponse]).
+If access to the underlying [Node.js][Node.js] request and response objects is required (only in Node.js runtime), you can access them via `request.runtime?.node?.req` ([node:IncomingMessage][IncomingMessage]) and `request.runtime?.node?.res` ([node:ServerResponse][ServerResponse]).
 
 ```js
 import { serve } from "srvx";

--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -30,7 +30,7 @@ serve({
 
 ### `request.ip?`
 
-Using `request.ip` allows to access connected client's ipv address.
+Using `request.ip` allows to access connected client's IP address.
 
 ```js
 import { serve } from "srvx";

--- a/src/_node-compat/request.ts
+++ b/src/_node-compat/request.ts
@@ -19,20 +19,21 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     #bodyStream?: undefined | ReadableStream<Uint8Array>;
 
     _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
-    x: ServerRuntimeContext;
+    runtime: ServerRuntimeContext;
 
     constructor(nodeCtx: {
       req: NodeHttp.IncomingMessage;
       res?: NodeHttp.ServerResponse;
     }) {
       this._node = nodeCtx;
-      this.x = {
-        runtime: "node",
+      this.runtime = {
+        name: "node",
         node: nodeCtx,
-        get ip() {
-          return nodeCtx.req.socket?.remoteAddress;
-        },
       };
+    }
+
+    get ip() {
+      return this._node.req.socket?.remoteAddress;
     }
 
     get headers() {

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -24,12 +24,14 @@ class BunServer implements Server<BunFetchHandler> {
     const fetchHandler = wrapFetch(this, this.options.fetch);
 
     this.fetch = (request, server) => {
-      Object.defineProperty(request, "x", {
-        enumerable: true,
-        value: {
-          runtime: "bun",
-          bun: { server },
-          get ip() {
+      Object.defineProperties(request, {
+        runtime: {
+          enumerable: true,
+          value: { runtime: "bun", bun: { server } },
+        },
+        ip: {
+          enumerable: true,
+          get() {
             return server?.requestIP(request as Request)?.address;
           },
         },

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -29,12 +29,18 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
     );
 
     this.fetch = (request, env, context) => {
-      Object.defineProperty(request, "x", {
-        enumerable: true,
-        value: {
-          runtime: "cloudflare",
-          cloudflare: { env, context },
+      Object.defineProperties(request, {
+        runtime: {
+          enumerable: true,
+          value: { runtime: "cloudflare", cloudflare: { env, context } },
         },
+        // TODO
+        // ip: {
+        //   enumerable: true,
+        //   get() {
+        //     return;
+        //   },
+        // },
       });
       return fetchHandler(request as unknown as Request) as unknown as
         | CF.Response

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -28,12 +28,14 @@ class DenoServer implements Server<DenoFetchHandler> {
     const fetchHandler = wrapFetch(this, this.options.fetch);
 
     this.fetch = (request, info) => {
-      Object.defineProperty(request, "x", {
-        enumerable: true,
-        value: {
-          runtime: "deno",
-          deno: { info, server: this.deno?.server },
-          get ip() {
+      Object.defineProperties(request, {
+        runtime: {
+          enumerable: true,
+          value: { runtime: "deno", deno: { info, server: this.deno?.server } },
+        },
+        ip: {
+          enumerable: true,
+          get() {
             return (info?.remoteAddr as Deno.NetAddr)?.hostname;
           },
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,12 +207,7 @@ export interface ServerPluginInstance {
 // ----------------------------------------------------------------------------
 
 export interface ServerRuntimeContext {
-  runtime: "node" | "deno" | "bun" | "cloudflare" | (string & {});
-
-  /**
-   * IP address of the client.
-   */
-  ip?: string | undefined;
+  name: "node" | "deno" | "bun" | "cloudflare" | (string & {});
 
   /**
    * Underlying Node.js server request info.
@@ -249,7 +244,12 @@ export interface ServerRequest extends Request {
   /**
    * Runtime specific request context.
    */
-  x?: ServerRuntimeContext;
+  runtime?: ServerRuntimeContext;
+
+  /**
+   * IP address of the client.
+   */
+  ip?: string | undefined;
 }
 
 // ----------------------------------------------------------------------------

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -40,7 +40,7 @@ export const server = serve({
       }
       case "/headers": {
         // Trigger Node.js writeHead slowpath to reproduce https://github.com/unjs/srvx/pull/40
-        req.x?.node?.res?.setHeader("x-set-with-node", "");
+        req.runtime?.node?.res?.setHeader("x-set-with-node", "");
         const resHeaders = new Headers();
         for (const [key, value] of req.headers) {
           resHeaders.append(`x-req-${key}`, value);
@@ -62,7 +62,7 @@ export const server = serve({
         return new Response(await req.text());
       }
       case "/ip": {
-        return new Response(`ip: ${req.x?.ip}`);
+        return new Response(`ip: ${req.ip}`);
       }
       case "/req-instanceof": {
         return new Response(req instanceof Request ? "yes" : "no");


### PR DESCRIPTION
quick turnover from #50

Using more clearer `request.ip` and `request.runtime` namespaces.

(votes from [nitro discord](https://discord.nitro.build))

![image](https://github.com/user-attachments/assets/c1a79aa7-1fe2-4d5e-aa21-bf6e5109fda1)
